### PR TITLE
Remove usage of `MeasurementProcess.return_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * With the introduction of custom measurement classes, all the `MeasurementProcess.return_type`
   checks have been changed by `isinstance` checks.
-  [(#388)](https://github.com/PennyLaneAI/pennylane-lightning/pull/388)
+  [(#118)](https://github.com/PennyLaneAI/pennylane-rigetti/pull/118)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* With the introduction of custom measurement classes, all the `MeasurementProcess.return_type`
+  checks have been changed by `isinstance` checks.
+  [(#388)](https://github.com/PennyLaneAI/pennylane-lightning/pull/388)
+
 ### Documentation
 
 ### Bug fixes
@@ -14,6 +18,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Albert Mitjans-Coma
 ---
 
 # Release 0.27.0

--- a/pennylane_rigetti/qpu.py
+++ b/pennylane_rigetti/qpu.py
@@ -194,7 +194,7 @@ class QPUDevice(QuantumComputerDevice):
 
     def execute(self, circuit: QuantumTape, **kwargs):
         self._skip_generate_samples = (
-            all(obs.return_type == Expectation for obs in circuit.observables)
+            all(isinstance(obs, Expectation) for obs in circuit.observables)
             and not self.parametric_compilation
         )
 


### PR DESCRIPTION
❗ DO NOT MERGE before this PR: PennyLaneAI/pennylane#3425