### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,14 +5,13 @@ on:
       - master
   pull_request:
 
-
 jobs:
   tests:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: ["3.8", "3.10"]
 
     steps:
       - name: Cancel Previous Runs
@@ -55,6 +54,10 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.10"]
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -72,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
 
       - name: Install requirements
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,29 +1,29 @@
-# .readthedocs.yaml
+# .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.8"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py
 
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
 
-# Optionally declare the Python requirements required to build your docs
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - htmlzip
+
+# Optionally set the version of Python and requirements required to build your docs
 python:
+  version: 3.8
   install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .
+
+build:
+  image: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 * `pennylane-rigetti` no longer supports `python3.7`. A newer python version is required.
+  [(#121)](https://github.com/PennyLaneAI/pennylane-rigetti/pull/121)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* `pennylane-rigetti` no longer supports `python3.7`. A newer python version is required.
+
 ### Improvements
 
 ### Documentation
@@ -13,6 +15,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Albert Mitjans Coma
 
 ---
 
@@ -36,7 +40,7 @@ as a PennyLane device.
   [#110](https://github.com/PennyLaneAI/pennylane-forest/pull/110)
 
 * A new version of the QCS CLI is required if you want to use your QCS account
-  to run your workloads on a live Rigetti QPU. See 
+  to run your workloads on a live Rigetti QPU. See
   [Using the QCS CLI](https://docs.rigetti.com/qcs/guides/using-the-qcs-cli) for
   details.
   [#107](https://github.com/PennyLaneAI/pennylane-forest/pull/107)
@@ -70,8 +74,8 @@ as a PennyLane device.
 
 ### Bug fixes
 
-* The QPU device now correctly sets the number of shots when parametric 
-  compilation is disabled. 
+* The QPU device now correctly sets the number of shots when parametric
+  compilation is disabled.
   [#107](https://github.com/PennyLaneAI/pennylane-forest/pull/107)
 
 ### Contributors

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Dependencies
 
 PennyLane-Rigetti requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >=3.7
+* `Python <http://python.org/>`__ >=3.8
 
 as well as the following Python packages:
 

--- a/pennylane_rigetti/qpu.py
+++ b/pennylane_rigetti/qpu.py
@@ -123,10 +123,8 @@ class QPUDevice(QuantumComputerDevice):
 
         # `measure_observables` called only when parametric compilation is turned off
         if not self.parametric_compilation:
-
             # Single-qubit observable
             if len(device_wires) == 1:
-
                 # Ensure sensible observable
                 assert observable.name in [
                     "PauliX",
@@ -142,7 +140,6 @@ class QPUDevice(QuantumComputerDevice):
 
             # Multi-qubit observable
             elif len(device_wires) > 1 and isinstance(observable, Tensor):
-
                 # All observables are rotated to be measured in the Z-basis, so we just need to
                 # check which wires exist in the observable, map them to physical qubits, and measure
                 # the product of PauliZ operators on those qubits

--- a/pennylane_rigetti/wavefunction.py
+++ b/pennylane_rigetti/wavefunction.py
@@ -129,7 +129,6 @@ class WavefunctionDevice(RigettiDevice):
 
         for string, amplitude in zip(subsystem_bit_strings, self._state):
             for w in inactive_wires:
-
                 # expand the bitstring by inserting a zero bit for each inactive qubit
                 string = np.insert(string, w, 0)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import sys
 import os
+import sys
+
 from setuptools import setup
 
 with open("pennylane_rigetti/_version.py") as f:
@@ -49,7 +50,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- Copy `.readthedocs.yaml` configuration file from PL to avoid using `python3.7` to build the docs.
- Update `tests.yml` workflow to stop using `python3.7` in `integration-tests`.
- Run `black`.