### PR TITLE
Fix Upload Github Action

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -20,11 +20,14 @@ jobs:
       - name: Run Forest QVM
         run: docker run --rm -d -p 5000:5000 rigetti/qvm -S
 
-      - name: Install plugin and test dependencies
+      - name: Build and install Plugin
         run: |
           python -m pip install --upgrade pip wheel
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
+
+      - name: Install test dependencies
+        run: |
           pip install '.[test]'
 
       - name: Run tests

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Install plugin and test dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
+          python setup.py bdist_wheel
+          pip install dist/PennyLane*.whl
           pip install '.[test]'
 
       - name: Run tests


### PR DESCRIPTION
Can't upload plugin to PyPI to to failing Upload GitHub action. This PR updates the action to (hopefully) work as expected.