### PR TITLE
unpin numpy and fix BasisState test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.21,<1.24
+numpy>=1.21
 networkx>=2.5,<3.0
 pennylane>=0.32
 pyquil>=3.0.0,<4.0.0

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -14,7 +14,7 @@ def test_simulator_qvm_default_agree(tol, qvm, compiler):
     dev2 = qml.device("rigetti.wavefunction", wires=w)
     dev3 = qml.device("rigetti.qvm", device="9q-square-qvm", shots=5000)
 
-    in_state = np.zeros([w], requires_grad=False)
+    in_state = np.zeros([w], dtype=np.int64, requires_grad=False)
     in_state[0] = 1
     in_state[1] = 1
 


### PR DESCRIPTION
this BasisState test fails because PL now uses the inputs as numpy array indices, so they should be integers. We can cast to ints on the PL side, but this should do for now. If people feel strongly about this casting, I can do it at the source (should be pretty straightforward)