### PR TITLE
`QubitDevice` is now imported from `pennylane.devices`

### DIFF
--- a/pennylane_rigetti/device.py
+++ b/pennylane_rigetti/device.py
@@ -63,7 +63,8 @@ from pyquil.gates import (
     PSWAP,
 )
 
-from pennylane import QubitDevice, DeviceError
+from pennylane import DeviceError
+from pennylane.devices import QubitDevice
 from pennylane.wires import Wires
 
 from ._version import __version__


### PR DESCRIPTION
`pennylane.QubitDevice` is deprecated in v0.39, importing `QubitDevice` from `pennylane.devices` instead.