### PR TITLE
Remove tests with deprecated `QubitStateVector`

### DIFF
--- a/pennylane_rigetti/device.py
+++ b/pennylane_rigetti/device.py
@@ -63,7 +63,8 @@ from pyquil.gates import (
     PSWAP,
 )
 
-from pennylane import QubitDevice, DeviceError
+from pennylane import DeviceError
+from pennylane.devices import QubitDevice
 from pennylane.wires import Wires
 
 from ._version import __version__

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -126,14 +126,13 @@ class TestMatVecProduct:
         ):
             dev.apply(queue)
 
-    @pytest.mark.parametrize("op", [qml.StatePrep, qml.QubitStateVector])
-    def test_apply_statesvector_raises_an_error_if_not_first(self, op):
-        """Test that there is an error raised when the QubitStateVector or StatePrep op is not
+    def test_apply_statesvector_raises_an_error_if_not_first(self):
+        """Test that there is an error raised when the StatePrep op is not
         applied as the first operation."""
         wires = 1
         dev = RigettiDevice(wires=wires, shots=1)
 
-        operation = op(np.array([1, 0]), wires=list(range(wires)))
+        operation = qml.StatePrep(np.array([1, 0]), wires=list(range(wires)))
         queue = [qml.PauliX(0), operation]
         with pytest.raises(
             qml.DeviceError,

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -607,13 +607,12 @@ class TestParametricCompilation(BaseTest):
         assert len(dev._compiled_program_dict.items()) == 1
         assert mock_qvm.compile.call_count == 1
 
-    @pytest.mark.parametrize("op", [qml.QubitStateVector, qml.StatePrep])
-    def test_apply_qubitstatesvector_raises_an_error_if_not_first(self, op):
-        """Test that there is an error raised when the QubitStateVector or StatPrep is not
+    def test_apply_qubitstatesvector_raises_an_error_if_not_first(self):
+        """Test that there is an error raised when the StatPrep is not
         applied as the first operation."""
         dev = qml.device("rigetti.qvm", device="2q-qvm", parametric_compilation=True)
 
-        operation = op(np.array([1, 0]), wires=[0])
+        operation = qml.StatePrep(np.array([1, 0]), wires=[0])
         queue = [qml.PauliX(0), operation]
         with pytest.raises(
             qml.DeviceError,


### PR DESCRIPTION
`QubitStateVector` is removed in the latest master of PL