### PR TITLE
upgrade readthedocs to ubuntu 24

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,7 +25,7 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   apt_packages:


### PR DESCRIPTION
**Description of the Change:**
Upgrading the readthedocs.yml runner to Ubuntu-24.04 from Ubuntu22.04; 22.04 is in end of life.

**Benefits:**
The readthedocs runner gets upgrade.

**Possible Drawbacks:**
There could be potential compatibility issues with sphinx and other packages. None were found in the PR run.

**Related GitHub Issues:**
